### PR TITLE
Fix Syntax Group Variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ host-01
 host-02
 
 [coreos:vars]
-ansible_python_interpreter: "/home/core/bin/python"
+ansible_python_interpreter="/home/core/bin/python"
 ```
 
 This will configure ansible to use the python interpreter at `$HOME/bin/python` which will be created by the coreos-bootstrap role.


### PR DESCRIPTION
Was getting this error with the previous syntax:

``` sh
ERROR: variables assigned to group must be in key=value form
```
