### PR TITLE
Dynamic bootstrap

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -2,28 +2,28 @@
 
 set -e
 
-if [-e $HOME/.bootstrapped]; then
-  exit 0
-fi
+if ! [ `PATH=$HOME/bin:$PATH which python` ]; then
+   echo Bootstrapping Python
+   PYPY_VERSION=2.4.0
 
-PYPY_VERSION=2.4.0
+   wget https://bitbucket.org/pypy/pypy/downloads/pypy-$PYPY_VERSION-linux64.tar.bz2
+   tar -xf pypy-$PYPY_VERSION-linux64.tar.bz2
+   ln -s pypy-$PYPY_VERSION-linux64 pypy
 
-wget https://bitbucket.org/pypy/pypy/downloads/pypy-$PYPY_VERSION-linux64.tar.bz2
-tar -xf pypy-$PYPY_VERSION-linux64.tar.bz2
-ln -s pypy-$PYPY_VERSION-linux64 pypy
+   ## library fixup
+   mkdir pypy/lib
+   ln -s /lib64/libncurses.so.5.9 $HOME/pypy/lib/libtinfo.so.5
 
-## library fixup
-mkdir pypy/lib
-ln -s /lib64/libncurses.so.5.9 $HOME/pypy/lib/libtinfo.so.5
+   mkdir -p $HOME/bin
 
-mkdir -p $HOME/bin
-
-cat > $HOME/bin/python <<EOF
+   cat > $HOME/bin/python <<EOF
 #!/bin/bash
 LD_LIBRARY_PATH=$HOME/pypy/lib:$LD_LIBRARY_PATH $HOME/pypy/bin/pypy "\$@"
 EOF
 
-chmod +x $HOME/bin/python
-$HOME/bin/python --version
+   chmod +x $HOME/bin/python
+   $HOME/bin/python --version
+fi
 
-touch $HOME/.bootstrapped
+python=`PATH=$HOME/bin:$PATH which python`
+echo $python

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,17 @@
-- name: check if bootstrap is needed
-  raw: stat $HOME/.bootstrapped
-  register: need_bootstrap
-  ignore_errors: True
-
 - name: Run bootstrap.sh
   script: bootstrap.sh
-  when: need_bootstrap | failed
+  register: python_path
+  changed_when: "'Bootstrapping' in python_path.stdout"
+
+- name: Set the python interpreter if needed
+  set_fact: ansible_python_interpreter={{ python_path.stdout_lines[python_path.stdout_lines|length-1] }}
+  when: ansible_python_interpreter is not defined
 
 - name: Check if we need to install pip
   shell: "{{ansible_python_interpreter}} -m pip --version"
   register: need_pip
   ignore_errors: True
+  changed_when: false
 
 - name: Copy get-pip.py
   copy: src=get-pip.py dest=/home/core/get-pip.py
@@ -22,3 +23,6 @@
 
 - name: Install pip launcher
   copy: src=runner dest=/home/core/bin/pip mode=0755
+
+- name: Now gather facts
+  setup:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,12 @@
   script: bootstrap.sh
   register: python_path
   changed_when: "'Bootstrapping' in python_path.stdout"
+  when: ansible_python_interpreter is not defined
 
 - name: Set the python interpreter if needed
-  set_fact: ansible_python_interpreter={{ python_path.stdout_lines[python_path.stdout_lines|length-1] }}
+  set_fact: 
+     ansible_python_interpreter: "{{ python_path.stdout_lines[python_path.stdout_lines|length-1] }}"
+     python_bootstrap_needed: True
   when: ansible_python_interpreter is not defined
 
 - name: Check if we need to install pip
@@ -12,6 +15,7 @@
   register: need_pip
   ignore_errors: True
   changed_when: false
+  when: python_bootstrap_needed
 
 - name: Copy get-pip.py
   copy: src=get-pip.py dest=/home/core/get-pip.py


### PR DESCRIPTION
Here's a few changes that I made while using your role.  Including the role 'just works'.  Hosts that don't have Python get bootstrapped, and the others are unchanged.

Changes in a nutshell:
- Just check if Python is available, and bootstrap if it's not
- Always run the bootstrap.sh, as it returns the path to python 
- Only flags tasks as changed when they change something (install Python, pip, etc.)
- Gathers facts at the end so other roles can function as normal