### PR TITLE
Fix docker module 1.8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,3 +23,6 @@
 
 - name: Install pip launcher
   copy: src=runner dest=/home/core/bin/pip mode=0755
+
+- name: Install doker-py
+  pip: name=docker-py


### PR DESCRIPTION
Docker-py is required by the last version of the module.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>