### PR TITLE
Added /root/bin to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ host-02
 
 [coreos:vars]
 ansible_ssh_user=core
-ansible_python_interpreter="PATH=/home/core/bin:$PATH python"
+ansible_python_interpreter="PATH=/root/bin:/home/core/bin:$PATH python"
 ```
 
 This will configure ansible to use the python interpreter at `/home/core/bin/python` which will be created by the coreos-bootstrap role.


### PR DESCRIPTION
For various reasons we use the root user for deployment, to support this we need to add /root/bin to Python path.