### PR TITLE
skip all actions when bootstrapped

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
   register: need_pip
   ignore_errors: True
   changed_when: false
+  when: need_bootstrap | failed
 
 - name: Copy get-pip.py
   copy: src=get-pip.py dest=~/get-pip.py
@@ -23,7 +24,8 @@
 
 - name: Remove get-pip.py
   command: rm -f ~/get-pip.py
-  ignore_errors: True
+  when: need_pip | failed
 
 - name: Install pip launcher
   copy: src=runner dest=~/bin/pip mode=0755
+  when: need_pip | failed


### PR DESCRIPTION
Hello.
First, thank you very much for helping with Ansible on CoreOS.

Now, I'm a performance freak and looking for ways to remove the horrible 20 seconds penalty on subsequent bootstrap checks.
Ideally, whole `tasks/main.yml` must stop early after `.bootstrapped` file is discovered, right? Works for me, hope others will like it too.

before
```
% time ansible-playbook -i inventory site.yml -l dobro
PLAY [coreos] ***************************************************************** 

TASK: [defunctzombie.coreos-bootstrap | Check if bootstrap is needed] ********* 
ok: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Run bootstrap.sh] ********************* 
skipping: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Check if we need to install pip] ****** 
ok: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Copy get-pip.py] ********************** 
skipping: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Install pip] ************************** 
skipping: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Remove get-pip.py] ******************** 
changed: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Install pip launcher] ***************** 
ok: [dobro-host1]

PLAY [all] ******************************************************************** 

GATHERING FACTS *************************************************************** 
ok: [dobro-host1]

PLAY [dobro] ****************************************************************** 

GATHERING FACTS *************************************************************** 
ok: [dobro-host1]

PLAY RECAP ******************************************************************** 
dobro-host1                : ok=6    changed=1    unreachable=0    failed=0   

ansible-playbook -i inventory site.yml -l dobro  0.49s user 0.21s system 3% cpu 19.256 total
```
after
```
% time ansible-playbook -i inventory site.yml -l dobro

PLAY [coreos] ***************************************************************** 

TASK: [defunctzombie.coreos-bootstrap | Check if bootstrap is needed] ********* 
ok: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Run bootstrap.sh] ********************* 
skipping: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Check if we need to install pip] ****** 
skipping: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Copy get-pip.py] ********************** 
skipping: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Install pip] ************************** 
skipping: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Remove get-pip.py] ******************** 
skipping: [dobro-host1]

TASK: [defunctzombie.coreos-bootstrap | Install pip launcher] ***************** 
skipping: [dobro-host1]

PLAY [all] ******************************************************************** 

PLAY [dobro] ****************************************************************** 

PLAY RECAP ******************************************************************** 
dobro-host1                : ok=1    changed=0    unreachable=0    failed=0   

ansible-playbook -i inventory site.yml -l dobro  0.32s user 0.11s system 65% cpu 0.654 total
```