### PR TITLE
bootstrap.sh random fixes

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -4,30 +4,27 @@ set -e
 
 cd
 
-if [-e $HOME/.bootstrapped]; then
+if [[ -e $HOME/.bootstrapped ]]; then
   exit 0
 fi
 
 PYPY_VERSION=2.4.0
 
-wget https://bitbucket.org/pypy/pypy/downloads/pypy-$PYPY_VERSION-linux64.tar.bz2
-tar -xf pypy-$PYPY_VERSION-linux64.tar.bz2
-mv pypy-$PYPY_VERSION-linux64 pypy
+wget -O - https://bitbucket.org/pypy/pypy/downloads/pypy-$PYPY_VERSION-linux64.tar.bz2 |tar -xjf -
+mv -n pypy-$PYPY_VERSION-linux64 pypy
 
 ## library fixup
-mkdir pypy/lib
-ln -s /lib64/libncurses.so.5.9 $HOME/pypy/lib/libtinfo.so.5
+mkdir -p pypy/lib
+ln -snf /lib64/libncurses.so.5.9 $HOME/pypy/lib/libtinfo.so.5
 
 mkdir -p $HOME/bin
 
 cat > $HOME/bin/python <<EOF
 #!/bin/bash
-LD_LIBRARY_PATH=$HOME/pypy/lib:$LD_LIBRARY_PATH $HOME/pypy/bin/pypy "\$@"
+LD_LIBRARY_PATH=$HOME/pypy/lib:$LD_LIBRARY_PATH exec $HOME/pypy/bin/pypy "\$@"
 EOF
 
 chmod +x $HOME/bin/python
 $HOME/bin/python --version
 
 touch $HOME/.bootstrapped
-
-rm -f pypy-$PYPY_VERSION-linux64.tar.bz2


### PR DESCRIPTION
- if [-e  command not found, details below
- wget to stdout without intermediate file
- mv -n pypy...  skips if target already exists
- mkdir -p pypy/lib   works if target already exists
- ln -snf  works if target already exists
- ~/bin/python exec   to remove hanging bash waiting for pypy to finish

Details on [-e: `stdout: /home/core/.ansible/tmp/ansible-tmp-1425296644.0-190374525996480/bootstrap.sh: line 7: [-e: command not found`
Single bracket is alias to [/usr]/bin/test and so it requires space before first argument. Double bracket is bash built in construct, so it doesn't fork/exec to verify existence of a file.