### PR TITLE
README.md and bootstrap.sh changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ host-02
 
 [coreos:vars]
 ansible_ssh_user=core
-ansible_python_interpreter="PATH=/home/core/bin:$PATH python"
+ansible_python_interpreter="/home/core/bin/python"
 ```
 
 This will configure ansible to use the python interpreter at `/home/core/bin/python` which will be created by the coreos-bootstrap role.

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -4,19 +4,24 @@ set -e
 
 cd
 
+## if already bootstrapped, quit
 if [[ -e $HOME/.bootstrapped ]]; then
   exit 0
 fi
 
+## define download version and URL
 PYPY_VERSION=2.4.0
+PYPY_URL=https://bitbucket.org/pypy/pypy/downloads
 
-wget -O - https://bitbucket.org/pypy/pypy/downloads/pypy-$PYPY_VERSION-linux64.tar.bz2 |tar -xjf -
+## download and untar pypy
+wget -O - $PYPY_URL/pypy-$PYPY_VERSION-linux64.tar.bz2 |tar -xjf -
 mv -n pypy-$PYPY_VERSION-linux64 pypy
 
 ## library fixup
 mkdir -p pypy/lib
 ln -snf /lib64/libncurses.so.5.9 $HOME/pypy/lib/libtinfo.so.5
 
+## create python shell stub
 mkdir -p $HOME/bin
 
 cat > $HOME/bin/python <<EOF
@@ -24,7 +29,9 @@ cat > $HOME/bin/python <<EOF
 LD_LIBRARY_PATH=$HOME/pypy/lib:$LD_LIBRARY_PATH exec $HOME/pypy/bin/pypy "\$@"
 EOF
 
+## make stub executable
 chmod +x $HOME/bin/python
 $HOME/bin/python --version
 
+## create .bootstrapped file to bypass
 touch $HOME/.bootstrapped


### PR DESCRIPTION
I am using a 5 node coreos cluster and ran into some issues, proposed changes:

1. the ansible_python_interpreter variable setting in the README.md didn't work for me, I had to change it (tested working)
2. I use an offline mirror of the pypy tar file, I made the download URL a variable to easily repoint the location
3. Added some comments to bootstrap.sh