### PR TITLE
Replace raw rm call with file state=absent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
   when: need_pip | failed
 
 - name: Remove get-pip.py
-  command: rm -f ~/get-pip.py
+  file: path=~/get-pip.py state=absent
   when: need_pip | failed
 
 - name: Install pip launcher


### PR DESCRIPTION
Replace raw rm call with the file modules `state=absent`. This is an issue `ansible-lint` is complaining about.