### PR TITLE
Ability to install pypy through pre-downloaded archive

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -10,7 +10,13 @@ fi
 
 PYPY_VERSION=2.4.0
 
-wget -O - https://bitbucket.org/pypy/pypy/downloads/pypy-$PYPY_VERSION-linux64.tar.bz2 |tar -xjf -
+if [[ -e $HOME/pypy-$PYPY_VERSION-linux64.tar.bz2 ]]; then
+  tar -xjf $HOME/pypy-$PYPY_VERSION-linux64.tar.bz2
+  rm -rf $HOME/pypy-$PYPY_VERSION-linux64.tar.bz2
+else
+  wget -O - https://bitbucket.org/pypy/pypy/downloads/pypy-$PYPY_VERSION-linux64.tar.bz2 |tar -xjf -
+fi
+
 mv -n pypy-$PYPY_VERSION-linux64 pypy
 
 ## library fixup


### PR DESCRIPTION
Very useful in China, where Amazon AWS is blocked.

My use case. I'm using it with Vagrant.

Below is part of my Vagrantfile, related to this ansible role:

```ruby
$pypy_version = '2.4.0'

PYPY_PATH = File.join(File.dirname(__FILE__), 'pypy-%s-linux64.tar.bz2' % $pypy_version)

if File.exist?(PYPY_PATH) == false
  open('pypy-%s-linux64.tar.bz2' % $pypy_version, 'wb') do |file|
    file << open('https://bintray.com/artifact/download/donbeave/generic/pypy-%s-linux64.tar.bz2' % $pypy_version).read
  end
end

config.vm.provision :file, :source => "#{PYPY_PATH}", :destination => '/home/core/pypy-%s-linux64.tar.bz2' % $pypy_version
```

In this case, not need to download pypy everytime while bootstrap playbook:

```
ansible-playbook -i inventory/vagrant bootstrap.yml
```