### PR TITLE
Test for pip became main check for bootstrap installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,17 @@
-- name: Check if bootstrap is needed
-  raw: stat $HOME/.bootstrapped
-  register: need_bootstrap
-  ignore_errors: True
-
-- name: Run bootstrap.sh
-  script: bootstrap.sh
-  when: need_bootstrap | failed
-
 - name: Check if we need to install pip
   shell: "{{ansible_python_interpreter}} -m pip --version"
   register: need_pip
   ignore_errors: True
   changed_when: false
+
+- name: Check if bootstrap is needed
+  raw: stat $HOME/.bootstrapped
+  register: need_bootstrap
+  ignore_errors: True
+  when: need_pip | failed
+
+- name: Run bootstrap.sh
+  script: bootstrap.sh
   when: need_bootstrap | failed
 
 - name: Copy get-pip.py


### PR DESCRIPTION
For first time installing bootstrap I forgot to define variable "ansible_python_interpreter". Bootstrap didn't install pip. On repeated runs all checks were skipped.

So I made pip check to be main test for bootstrap installation. All other checks are skipped if pip check is successful.