### PR TITLE
fix symbolic link to libncurses

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -21,7 +21,7 @@ mv -n pypy-$PYPY_VERSION-linux64 pypy
 
 ## library fixup
 mkdir -p pypy/lib
-ln -snf /lib64/libncurses.so.5.9 $HOME/pypy/lib/libtinfo.so.5
+ln -snf /usr/lib64/libncurses.so.5.9 $HOME/pypy/lib/libtinfo.so.5
 
 mkdir -p $HOME/bin
 


### PR DESCRIPTION

Error when attempting to run bootstrap.yml playbook:

```
failed: [core-02] => {"changed": false, "cmd": "PATH=/home/core/bin:$PATH python -m pip --version", "delta": "0:00:00.037774", "end": "2016-02-12 19:31:39.809463", "rc": 1, "start": "2016-02-12 19:31:39.771689", "stdout_lines": [], "warnings": []}
stderr: /home/core/pypy/bin/pypy: /lib64/libssl.so.1.0.0: no version information available (required by /home/core/pypy/bin/pypy)
/home/core/pypy/bin/pypy: /lib64/libcrypto.so.1.0.0: no version information available (required by /home/core/pypy/bin/pypy)
/home/core/pypy/bin/pypy: No module named pip
```

Location of libncurses.so.5.9
```
$ sudo find / -name libncurses.so*
/usr/lib64/libncurses.so.5
/usr/lib64/libncurses.so.5.9
/usr/lib64/libncurses.so
```

relevant issue. 
https://github.com/defunctzombie/ansible-coreos-bootstrap/issues/14