### PR TITLE
gracefully check is already bootstrapped and pip is installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,31 +1,38 @@
 - name: Check if bootstrap is needed
-  raw: stat $HOME/.bootstrapped
+  raw: test -e $HOME/.bootstrapped || echo -n need_bootstrap
   register: need_bootstrap
-  ignore_errors: True
+  changed_when: false
+
+- name: Booleanize need_bootstrap
+  set_fact:
+    need_bootstrap={{need_bootstrap.stdout == "need_bootstrap"}}
 
 - name: Run bootstrap.sh
   script: bootstrap.sh
-  when: need_bootstrap | failed
+  when: need_bootstrap
 
 - name: Check if we need to install pip
-  shell: "{{ansible_python_interpreter}} -m pip --version"
+  shell: "{{ansible_python_interpreter}} -c 'import pkgutil; print(pkgutil.find_loader(\"pip\") is None)'"
   register: need_pip
-  ignore_errors: True
   changed_when: false
-  when: need_bootstrap | failed
+  when: need_bootstrap
+
+- name: Booleanize need_pip
+  set_fact:
+    need_pip={{need_bootstrap and need_pip.stdout == "True"}}
 
 - name: Copy get-pip.py
   copy: src=get-pip.py dest=~/get-pip.py
-  when: need_pip | failed
+  when: need_pip
 
 - name: Install pip
   shell: "{{ansible_python_interpreter}} ~/get-pip.py"
-  when: need_pip | failed
+  when: need_pip
 
 - name: Remove get-pip.py
   file: path=~/get-pip.py state=absent
-  when: need_pip | failed
+  when: need_pip
 
 - name: Install pip launcher
   copy: src=runner dest=~/bin/pip mode=0755
-  when: need_pip | failed
+  when: need_pip


### PR DESCRIPTION
Removes scary (ignored) error messages during playing:

```
TASK [defunctzombie.coreos-bootstrap : Check if bootstrap is needed] ***********
fatal: [master]: FAILED! => {"changed": false, "failed": true, "rc": 1, "stderr": "",
"stdout": "stat: cannot stat '/home/core/.bootstrapped': No such file or directory\r\n",
"stdout_lines": ["stat: cannot stat '/home/core/.bootstrapped': No such file or directory"]}
...ignoring

TASK [defunctzombie.coreos-bootstrap : Check if we need to install pip] ********
fatal: [master]: FAILED! => {"changed": false, "cmd": "PATH=/home/core/bin:$PATH
python -m pip --version", "delta": "0:00:00.031284", "end": "2016-03-09 20:42:58.787796",
"failed": true, "rc": 1, "start": "2016-03-09 20:42:58.756512",
"stderr": "/home/core/pypy/bin/pypy: /lib64/libssl.so.1.0.0: no version information available
(required by /home/core/pypy/bin/pypy)\n/home/core/pypy/bin/pypy: /lib64/libcrypto.so.1.0.0:
no version information available (required by /home/core/pypy/bin/pypy)\n/home/core/pypy/bin/pypy:
No module named pip", "stdout": "", "stdout_lines": [], "warnings": []}
...ignoring
```