### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ host-02
 
 [coreos:vars]
 ansible_ssh_user=core
-ansible_python_interpreter="PATH=/home/core/bin:$PATH python"
+ansible_python_interpreter=/home/core/bin/python
 ```
 
 This will configure ansible to use the python interpreter at `/home/core/bin/python` which will be created by the coreos-bootstrap role.


### PR DESCRIPTION
Fixes problems with 2.1.0 ansible
After updating ansible to 2.1.0 coreos playbooks failing. As mentioned here: https://github.com/ansible/ansible/issues/16063 this can be fixed by changing `ansible_python_interpreter` variable.