### PR TITLE
Add the magic back: $@ -> "$@"

### DIFF
--- a/files/runner
+++ b/files/runner
@@ -1,2 +1,2 @@
 #!/bin/bash
-LD_LIBRARY_PATH=$HOME/pypy/lib:$LD_LIBRARY_PATH $HOME/pypy/bin/$(basename $0) $@
+LD_LIBRARY_PATH=$HOME/pypy/lib:$LD_LIBRARY_PATH $HOME/pypy/bin/$(basename $0) "$@"


### PR DESCRIPTION
In bash "$@" is magic (expand arguments while preserving their boundaries). $@ is equivalent to $* and
"$*" is "interpolate all arguments into a single string, separated by the first character of the $IFS value.

Properly wrapping a command and preserving any arguments as they were quoted/escaped on the command line
requires "$@" ... the "magic" form of this variable.