### PR TITLE
Link the version of libncurses that is present

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -21,7 +21,8 @@ mv -n pypy-$PYPY_VERSION-linux64 pypy
 
 ## library fixup
 mkdir -p pypy/lib
-ln -snf /lib64/libncurses.so.5.9 $HOME/pypy/lib/libtinfo.so.5
+[ -f /lib64/libncurses.so.5.9 ] && ln -snf /lib64/libncurses.so.5.9 $HOME/pypy/lib/libtinfo.so.5
+[ -f /lib64/libncurses.so.6.1 ] && ln -snf /lib64/libncurses.so.6.1 $HOME/pypy/lib/libtinfo.so.5
 
 mkdir -p $HOME/bin
 


### PR DESCRIPTION
fixes #44 

This is a small change to bootstrap.sh that will symlink *either* version 5.9 or 6.1 of libncurses, depending on which is present on the system.

Based on @SleepyBrett's [comment](https://github.com/defunctzombie/ansible-coreos-bootstrap/issues/44#issuecomment-403661174)

This is a bit hacky, but worked for me to get multiple hosts on different versions of container Linux bootstrapped in one go. Tested on a group of hosts running both container linux 1745.7.0 and 1800.4.0